### PR TITLE
Create Placeholder for Credits in Landing Page

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -27,7 +27,7 @@ Number.prototype.pad = function(size: number): string
 
 // Determine browser via duck type hunting.
 // Note: IE stupidity is handled in index.html
-let isChrome = (!!(window as any).chrome && !!(window as any).chrome.webstore) as boolean;
+let isChrome = (!!(window as any).chrome) as boolean;
 
 /*
   let isOpera = (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -146,6 +146,13 @@ class LandingPageBase extends Component<Props, {}>
                                         </NavItem>
 
                                         <NavItem
+                                            eventKey="credit"
+                                            disabled={!context.state.currentMember}
+                                        >
+                                            Credits
+                                        </NavItem>
+
+                                        <NavItem
                                             eventKey="reports"
                                             disabled={!context.state.currentUser.IsAdmin}
                                         >
@@ -171,6 +178,10 @@ class LandingPageBase extends Component<Props, {}>
                                             {context.state.currentMember &&
                                                 <IntakePage/>
                                             }
+                                        </Tab.Pane>
+
+                                        <Tab.Pane eventKey="credit">
+                                            <p>Credits Placeholder</p>
                                         </Tab.Pane>
 
                                         <Tab.Pane eventKey="household">


### PR DESCRIPTION
- Placeholder created in Landing TabPage. See #5

- [Unrelated] Fix Browser Warning since Chrome Version 71.0.3578.80 removed the webstore we can no longer use this to "duck hunt" if this is Chrome or Chromium (both will now register as Chrome -- which is fine).