### PR TITLE
Fix Problem with Member Refresh

### DIFF
--- a/src/components/Household/HouseholdPage.tsx
+++ b/src/components/Household/HouseholdPage.tsx
@@ -258,7 +258,7 @@ class HouseholdPageBase extends Component<IProps, State>
             return;
         }
 
-        this.props.memberProvider.read(householdId, 'household_id')
+        this.props.memberProvider.read(householdId, 'HouseholdId')
         .then((response) =>
         {
             // Did we find the member(s)? If we didn't get any members it just means that this is a new household.

--- a/src/components/Member/MemberGrid.tsx
+++ b/src/components/Member/MemberGrid.tsx
@@ -31,27 +31,39 @@ export class MemberGrid extends Component<IProps, State>
     public readonly state: State = initialState;
 
     /**
+     * Lifecycle hook - getDerivedStateFromProps
+     *
+     * @param {IProps} nextProps
+     * @param {State} prevState
+     * @return {any}
+     */
+    public static getDerivedStateFromProps(nextProps: IProps, prevState: State)
+    {
+        // Is the initial state no members and nextProps have members? Initialize the array.
+        if (prevState.members === null && nextProps.members && nextProps.members.length > 0)
+        {
+            return {members: sortByColumnName(nextProps.members, prevState.sortBy) as MemberType[]};
+        } else {
+            return null;
+        }
+    }
+
+    /**
      * Lifecycle hook - componentDidUpdate
      *
      * @param {object} prevProps
      */
     public componentDidUpdate(prevProps: IProps)
     {
-        // Is this the initial assignment of member data?
-        if (this.state.members === null && this.props.members) {
-            this.setState({members: sortByColumnName(this.props.members, this.state.sortBy) as MemberType[]});
-        } else {
-            // Is the the members property not empty?
-            if (this.props.members) {
-                // Another reason to hate JS.
-                // There's not a native method to compare an array of objects so we have a hack via JSON.stringify:
-                const prevMembers = JSON.stringify(prevProps.members);
-                const currentMembers = JSON.stringify(this.props.members);
+        if (this.props.members) {
+            // Another reason to hate JS.
+            // There's not a native method to compare an array of objects so we have a hack via JSON.stringify:
+            const prevMembers = JSON.stringify(prevProps.members);
+            const currentMembers = JSON.stringify(this.props.members);
 
-                // Is there a change from the previous members array to the current members array?
-                if (prevMembers !== currentMembers) {
-                    this.setState({members: sortByColumnName(this.props.members, this.state.sortBy) as MemberType[]});
-                }
+            // Is there a change from the previous members array to the current members array?
+            if (prevMembers !== currentMembers) {
+                this.setState({members: sortByColumnName(this.props.members, this.state.sortBy) as MemberType[]});
             }
         }
     }

--- a/src/components/Search/SearchPage.tsx
+++ b/src/components/Search/SearchPage.tsx
@@ -183,7 +183,7 @@ class SearchPageBase extends Component<IProps, State>
         // We only kick off a search if the entered last name is 2 or more characters.
         if (nameInput.length > 1) {
             // Perform the search based on the entered last name using a Soft Search
-            this.props.memberProvider.read(nameInput, 'last_name', true)
+            this.props.memberProvider.read(nameInput, 'LastName', true)
             .then((response) =>
             {
                 // Did we find any member(s)?


### PR DESCRIPTION
- If a new household is added followed by a new member the member grid is not displayed.
- Closes: #25