### PR TITLE
Reset MemberGrid when searching

### DIFF
--- a/src/components/Search/SearchPage.tsx
+++ b/src/components/Search/SearchPage.tsx
@@ -199,6 +199,8 @@ class SearchPageBase extends Component<IProps, State>
             {
                 this.onError(error);
             });
+        } else {
+            this.setState({members: initialMembers});
         }
     }
 


### PR DESCRIPTION
- If the last name textbox is blank or only has one character reset the member grid.
- Closes: #29