### PR TITLE
Fix new user caching

### DIFF
--- a/src/components/User/UserPage.tsx
+++ b/src/components/User/UserPage.tsx
@@ -85,7 +85,7 @@ class UserPageBase extends Component<IProps, State>
         e.preventDefault();
 
         // Set the user record to an empty userModel and bring up the UserEdit modal form.
-        this.setState({userInfo: userModel, showUserEdit: true});
+        this.setState({userInfo: {...userModel}, showUserEdit: true});
     }
 
     /**


### PR DESCRIPTION
Adding a new user would keep the previous new user cached when new user was added.
Closes #34 